### PR TITLE
Spark multiversion support

### DIFF
--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
@@ -2311,10 +2311,10 @@ public class DistributedRegion extends LocalRegion implements
   @Override
   void cmnClearRegion(RegionEventImpl regionEvent, boolean cacheWrite, boolean useRVV) {
     boolean enableRVV = useRVV && this.dataPolicy.withReplication() && this.concurrencyChecksEnabled && !getDistributionManager().isLoner(); 
-    if(enableRVV && this instanceof BucketRegion) {
+    if (enableRVV && this instanceof BucketRegion) {
 	  //Prevent unnecessary creating distributedLock when destroy region
-      if(this.dlockService == null && ((BucketRegion)this).getRedundancyLevel()==0){
-          enableRVV=false;
+      if (this.dlockService == null && ((BucketRegion)this).getRedundancyLevel() == 0) {
+          enableRVV = false;
       }
     }
     //Fix for 46338 - apparently multiple threads from the same VM are allowed

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/DistributedRegion.java
@@ -2311,7 +2311,12 @@ public class DistributedRegion extends LocalRegion implements
   @Override
   void cmnClearRegion(RegionEventImpl regionEvent, boolean cacheWrite, boolean useRVV) {
     boolean enableRVV = useRVV && this.dataPolicy.withReplication() && this.concurrencyChecksEnabled && !getDistributionManager().isLoner(); 
-    
+    if(enableRVV && this instanceof BucketRegion) {
+	  //Prevent unnecessary creating distributedLock when destroy region
+      if(this.dlockService == null && ((BucketRegion)this).getRedundancyLevel()==0){
+          enableRVV=false;
+      }
+    }
     //Fix for 46338 - apparently multiple threads from the same VM are allowed
     //to suspend locking, which is what distributedLockForClear() does. We don't
     //want that to happen, so we'll synchronize to make sure only one thread on

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -914,7 +914,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                   if (re.isUpdateInProgress()) {
                     continue;
                   } else {
-                    if (notRequired(region, re, null,runningTXs)) {
+                    if (notRequired(region, re, null, runningTXs)) {
                       removeEntry(regionEntryMap, re, region);
                     }
                   }
@@ -926,7 +926,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
                     if (re.isUpdateInProgress()) {
                       continue;
                     } else {
-                      if (notRequired(region, re, oldEntriesQueue,runningTXs)) {
+                      if (notRequired(region, re, oldEntriesQueue, runningTXs)) {
                         if (SNAPSHOT_DEBUG || getLoggerI18n().fineEnabled()) {
                           getLoggerI18n().info(LocalizedStrings.DEBUG,
                                   "OldEntriesCleanerThread : Removing the entry " + re);

--- a/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
+++ b/gemfire-core/src/main/java/com/gemstone/gemfire/internal/cache/GemFireCacheImpl.java
@@ -897,7 +897,7 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
 
             //Only load TXState once for each region-snapshot
             Collection<TXStateProxy> txProxies = getTxManager().getHostedTransactionsInProgress();
-            List<TXState> runningTXs=new ArrayList<>();
+            List<TXState> runningTXs = new ArrayList<>();
             for (TXStateProxy txProxy : txProxies) {
               TXState txState = txProxy.getLocalTXState();
               if (txState != null && !txState.isClosed() && txState.isSnapshot()) {
@@ -1003,13 +1003,14 @@ public class GemFireCacheImpl implements InternalCache, ClientCache, HasCachePer
 
     }
 
-    boolean notRequired(LocalRegion region, RegionEntry re, BlockingQueue queue,Collection<TXState> runningTXs) {
+    boolean notRequired(LocalRegion region, RegionEntry re, BlockingQueue queue,
+                        Collection<TXState> runningTXs) {
       // 20% time just compare with the oldest tx.
       /*if (r.nextInt(100) < 20) {
         return notRequiredByOldest(region, re, queue);
       } else {*/
         return runningTXs.isEmpty() ||
-              notRequiredByAnyTx(region, re, queue,runningTXs);
+              notRequiredByAnyTx(region, re, queue, runningTXs);
       //}
     }
 


### PR DESCRIPTION
## Changes proposed in this pull request

Deploy in production with 10k tables for months,  revealed a lot of orphan lock grantors when 'DROP TABLE'; and 100% Thread CPU usage on OldEntriesCleanerThread.
This pull request fixed these:
* [Lock] Prevent unnecessary creating distributedLock when destroy region 
* [TX]     OldEtriesCleanThread may run very slow due to getHostedTransactionsInProgress() for each OldEntry,replaced as Batch Compare for gread performance enhance.
## Patch testing

Tested with multi on live production env.
(Fill in the details about how this patch was tested)

## Is precheckin with -Pstore clean?

## ReleaseNotes changes

(Does this change require an entry in ReleaseNotes? If yes, has it been added to it?)

## Other PRs 

(Does this change require changes in other projects- snappydata, spark, spark-jobserver, aqp? Add the links of PR of the other subprojects that are related to this change)
